### PR TITLE
Unicode

### DIFF
--- a/src/api/brow_sav.cpp
+++ b/src/api/brow_sav.cpp
@@ -34,9 +34,9 @@ SaveBrowser::SaveBrowser(const Filename&    bdir,
     level_list(2 * frame_offset + dir_list_xl,
      dir_list_y, file_list_xl, dir_list_yl),
 
-    file_name(2*frame_offset + dir_list_xl,
-     dir_list_y + dir_list_yl + frame_offset, 140, "",
-     false),  // for simplicity, disallow Unicode entry for filenames for now?
+    file_name(2 * frame_offset + dir_list_xl,
+              dir_list_y + dir_list_yl + frame_offset,
+              140, Texttype::ALLOW_ONLY_FILENAME),
 
     ok    (file_name.get_x() + 160, file_name.get_y(),  80),
     cancel(file_name.get_x() + 260, file_name.get_y(), 100),

--- a/src/api/texttype.cpp
+++ b/src/api/texttype.cpp
@@ -101,30 +101,26 @@ void Texttype::calc_self()
             // despite var name, can actually be Unicode character
             int kascii = hardware.get_key_ascii();
 
-            // Zeichen verarbeiten
+            // use the key and/or unicode value
             if (k == KEY_BACKSPACE && text.size() > 0) {
                 Help::remove_last_utf8_char(text);
             }
-            else if (kascii < 1) return;
-            else if ((k >= KEY_A     && k <= KEY_9    )  || k == KEY_SPACE
-             ||      (k >= KEY_0_PAD && k <= KEY_9_PAD)  || k == KEY_DEL_PAD
-             || k == KEY_STOP      || k == KEY_COMMA     || k == KEY_COLON
-             || k == KEY_MINUS     || k == KEY_PLUS_PAD  || k == KEY_EQUALS
-             || k == KEY_QUOTE     || k == KEY_SLASH     || k == KEY_CLOSEBRACE
-             || k == KEY_OPENBRACE || k == KEY_SEMICOLON || k == KEY_ASTERISK
-             || kascii > 0xFF)
-            {
-                if ((allow_chars == ALLOW_UNICODE)
-                 || (allow_chars == ALLOW_ONLY_ASCII    && kascii <= 0xFF)
-                 || (allow_chars == ALLOW_ONLY_FILENAME && kascii <= 0xFF
+            else if (kascii < 0x20) {
+                // anything under 0x20 are control characters -- tab, etc.,
+                // and I believe this also prevents keys like cursor-left
+                // that don't generate letters
+                return;
+            }
+            else if ((allow_chars == ALLOW_UNICODE)
+                  || (allow_chars == ALLOW_ONLY_ASCII    && kascii <= 0xFF)
+                  || (allow_chars == ALLOW_ONLY_FILENAME && kascii <= 0xFF
                      && kascii != '/' && kascii != '\\' && kascii != ':'
                      && kascii != '*' && kascii != '?'  && kascii != '"'
                      && kascii != '<' && kascii != '>'  && kascii != '|'))
-                {
-                    std::string::size_type oldsize = text.size();
-                    text += Help::make_utf8_seq(kascii);
-                    if (!scroll && get_too_long(text)) text.resize(oldsize);
-                }
+            {
+                std::string::size_type oldsize = text.size();
+                text += Help::make_utf8_seq(kascii);
+                if (!scroll && get_too_long(text)) text.resize(oldsize);
             }
             // Ende Tastenverarbeitung
         }

--- a/src/api/texttype.cpp
+++ b/src/api/texttype.cpp
@@ -105,10 +105,11 @@ void Texttype::calc_self()
             if (k == KEY_BACKSPACE && text.size() > 0) {
                 Help::remove_last_utf8_char(text);
             }
-            else if (kascii < 0x20) {
+            else if (kascii < 0x20 || kascii == 0x7F) {
                 // anything under 0x20 are control characters -- tab, etc.,
                 // and I believe this also prevents keys like cursor-left
                 // that don't generate letters
+                // 0x7F is the delete control character
                 return;
             }
             else if ((allow_chars == ALLOW_UNICODE)

--- a/src/api/texttype.cpp
+++ b/src/api/texttype.cpp
@@ -6,19 +6,18 @@
 namespace Api {
 
 Texttype::Texttype(const int x,  const int y,
-                   const int xl, const std::string& t,
-                   bool is_unicode_allowed)
+                   const int xl,
+                   AllowChars allow_ch)
 :
     Button(x, y, xl, 20), // 20 ist generell bei Textelementen richtig
     invisible    (false),
     scroll       (false),
-    unicode_ok   (is_unicode_allowed),
+    allow_chars  (allow_ch),
     on_enter_void(0),
     on_esc_void  (0),
     on_enter     (0),
     on_esc       (0)
 {
-    set_text(t);
 }
 
 
@@ -113,9 +112,15 @@ void Texttype::calc_self()
              || k == KEY_MINUS     || k == KEY_PLUS_PAD  || k == KEY_EQUALS
              || k == KEY_QUOTE     || k == KEY_SLASH     || k == KEY_CLOSEBRACE
              || k == KEY_OPENBRACE || k == KEY_SEMICOLON || k == KEY_ASTERISK
-             || kascii > 127)
+             || kascii > 0xFF)
             {
-                if (unicode_ok || kascii <= 127) {
+                if ((allow_chars == ALLOW_UNICODE)
+                 || (allow_chars == ALLOW_ONLY_ASCII    && kascii <= 0xFF)
+                 || (allow_chars == ALLOW_ONLY_FILENAME && kascii <= 0xFF
+                     && kascii != '/' && kascii != '\\' && kascii != ':'
+                     && kascii != '*' && kascii != '?'  && kascii != '"'
+                     && kascii != '<' && kascii != '>'  && kascii != '|'))
+                {
                     std::string::size_type oldsize = text.size();
                     text += Help::make_utf8_seq(kascii);
                     if (!scroll && get_too_long(text)) text.resize(oldsize);

--- a/src/api/texttype.h
+++ b/src/api/texttype.h
@@ -33,14 +33,22 @@
 namespace Api {
 class Texttype : public Button {
 
+public:
+
+    enum AllowChars {
+        ALLOW_UNICODE,
+        ALLOW_ONLY_ASCII,
+        ALLOW_ONLY_FILENAME
+    };
+
 private:
 
-    bool        invisible;    // Keinen Button zeichnen, nur den Eingabetext
-    bool        scroll;       // Mehr Text eingebbar, als das Feld lang ist
-    bool        unicode_ok;   // whether to allow non-ASCII characters
+    bool        invisible;   // Keinen Button zeichnen, nur den Eingabetext
+    bool        scroll;      // Mehr Text eingebbar, als das Feld lang ist
+    AllowChars  allow_chars; // whether to allow non-ASCII characters
 
     std::string text;
-    std::string text_backup;  // Bei ESC/Rechtsklick wird Zurueckgeschrieben
+    std::string text_backup; // Bei ESC/Rechtsklick wird Zurueckgeschrieben
 
     void*       on_enter_void;
     void*       on_esc_void;
@@ -52,7 +60,7 @@ private:
 
 public:
 
-    Texttype(const int, const int, const int, const std::string& = "", bool = true);
+    Texttype(const int, const int, const int, AllowChars = ALLOW_UNICODE);
     Texttype(Texttype&);
     virtual ~Texttype();
 

--- a/src/editor/win_var.cpp
+++ b/src/editor/win_var.cpp
@@ -18,9 +18,9 @@ WindowVariables::WindowVariables(Level& l)
     Window       (LEMSCR_X/2 - this_xl/2,
                   LEMSCR_Y/2 - this_yl/2 - 30,
                    this_xl, this_yl, Language::win_var_title),
-    author       (160,  40, 300,   l.author),
-    name_german  (160,  70, 300,   l.name_german),
-    name_english (160, 100, 300,   l.name_english),
+    author       (160,  40, 300),
+    name_german  (160,  70, 300),
+    name_english (160, 100, 300),
 
     initial      (160, 130, 180, 3, 1, 999,   l.initial,  true),
     required     (160, 160, 180, 3, 1, 999,   l.required, true),
@@ -55,6 +55,10 @@ WindowVariables::WindowVariables(Level& l)
     seconds.set_step_big(60);
     seconds.set_step_med(10);
     seconds.set_step_sml( 1);
+
+    author      .set_text(l.author);
+    name_german .set_text(l.name_german);
+    name_english.set_text(l.name_english);
 
     add_child(author);
     add_child(name_german);

--- a/src/menu/little.cpp
+++ b/src/menu/little.cpp
@@ -13,7 +13,7 @@ NewPlayerMenu::NewPlayerMenu()
 :
     Window(190, 170, 260, 140, Language::option_new_player_title),
     exit  (false),
-    name  ( 60, 100, 140, Texttype::ALLOW_ONLY_FILENAME),
+    name  ( 60, 100, 140, Texttype::ALLOW_UNICODE),
     desc_hello(get_xl()/2, 40, Language::option_new_player_first,
                 Label::CENTERED),
     desc_name (get_xl()/2, 60, Language::option_new_player_second,

--- a/src/menu/little.cpp
+++ b/src/menu/little.cpp
@@ -13,7 +13,7 @@ NewPlayerMenu::NewPlayerMenu()
 :
     Window(190, 170, 260, 140, Language::option_new_player_title),
     exit  (false),
-    name  ( 60, 100, 140, "", false),  // TODO: for now block non-ASCII chars in username
+    name  ( 60, 100, 140, Texttype::ALLOW_ONLY_FILENAME),
     desc_hello(get_xl()/2, 40, Language::option_new_player_first,
                 Label::CENTERED),
     desc_name (get_xl()/2, 60, Language::option_new_player_second,

--- a/src/menu/lobby.cpp
+++ b/src/menu/lobby.cpp
@@ -60,7 +60,7 @@ Lobby::Lobby()
     start_server(start_but_x, start_but_y + 1*start_but_ys, start_but_xl),
     start_client(start_but_x, start_but_y + 2*start_but_ys, start_but_xl/2),
     start_ip    (LEMSCR_X/2,  start_but_y + 2*start_but_ys, start_but_xl/2,
-                 "", false), // no Unicode allowed for this Texttype
+                 Texttype::ALLOW_ONLY_ASCII),
 
     chat        (20, console_y, console_xl),
     chat_type   (chat_type_x, chat_type_y,

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -65,7 +65,7 @@ OptionMenu::OptionMenu()
     button_cancel         (LEMSCR_X/2 +  10, 440, button_xl),
     pointers              (GROUP_MAX),
 
-    user_name             (other_x, 100, button_xl, "", false),  // TODO: for now block non-ASCII chars in username
+    user_name             (other_x, 100, button_xl, Texttype::ALLOW_ONLY_FILENAME),
     user_name_ask         (check_x, 100),
     language              (other_x, 130, button_xl),
     language_nr           (useR->language),
@@ -240,11 +240,10 @@ OptionMenu::OptionMenu()
     desc_me_main_replay   (key_t2, 160, Language::browser_replay_title),
     desc_me_main_options  (key_t2, 190, Language::option_title),
 
-    // false to disallow Unicode text entry in the resolution-related Texttypes
-    screen_resolution_x   (other_x, 100, button_xl/2, "", false),
-    screen_resolution_y   (370,     100, button_xl/2, "", false),
-    screen_windowed_x     (other_x, 130, button_xl/2, "", false),
-    screen_windowed_y     (370,     130, button_xl/2, "", false),
+    screen_resolution_x   (other_x, 100, button_xl/2, Texttype::ALLOW_ONLY_ASCII),
+    screen_resolution_y   (370,     100, button_xl/2, Texttype::ALLOW_ONLY_ASCII),
+    screen_windowed_x     (other_x, 130, button_xl/2, Texttype::ALLOW_ONLY_ASCII),
+    screen_windowed_y     (370,     130, button_xl/2, Texttype::ALLOW_ONLY_ASCII),
     screen_windowed       (check_x, 130),
     screen_scaling        (other_x, 160, button_xl),
     screen_border_colored (check_x, 160),

--- a/src/menu/options.cpp
+++ b/src/menu/options.cpp
@@ -65,7 +65,7 @@ OptionMenu::OptionMenu()
     button_cancel         (LEMSCR_X/2 +  10, 440, button_xl),
     pointers              (GROUP_MAX),
 
-    user_name             (other_x, 100, button_xl, Texttype::ALLOW_ONLY_FILENAME),
+    user_name             (other_x, 100, button_xl, Texttype::ALLOW_UNICODE),
     user_name_ask         (check_x, 100),
     language              (other_x, 130, button_xl),
     language_nr           (useR->language),

--- a/src/other/help.cpp
+++ b/src/other/help.cpp
@@ -93,6 +93,14 @@ std::string scancode_to_string(const int sc)
 
 
 
+static char single_hex_char(int i)
+{
+    if (i < 0xA) return '0' + i;
+    else         return 'A' + i - 0xA;
+}
+
+
+
 std::string int_to_hex(int i)
 {
     std::string ret;
@@ -103,9 +111,8 @@ std::string int_to_hex(int i)
     }
     if (i == 0) ret += '0';
     else while (i > 0) {
-        int digit = i % 0x10;
-        ret.insert(ret.begin(), digit >= 0 && digit <= 9 ? '0' + digit
-                                                         : 'A' + digit - 0xA);
+        const int digit = i % 0x10;
+        ret.insert(ret.begin(), single_hex_char(digit));
         i /= 0x10;
     }
     ret = (negative ? "-0x" : "0x") + ret;
@@ -139,6 +146,7 @@ bool string_ends_with(const std::string& s, const std::string& tail)
     return s.size() >= tail.size()
      && std::string(s.end() - tail.size(), s.end()) == tail;
 }
+
 
 
 void move_iterator_utf8(std::string const& str,
@@ -175,11 +183,15 @@ void move_iterator_utf8(std::string const& str,
     }
 }
 
+
+
 void remove_last_utf8_char(std::string& str) {
     std::string::const_iterator iter = str.end();
     move_iterator_utf8(str, iter, -1);
     str.resize(iter - str.begin());
 }
+
+
 
 std::string make_utf8_seq(int codepoint) {
     int num_bytes = ucwidth(codepoint);

--- a/src/other/help.cpp
+++ b/src/other/help.cpp
@@ -203,6 +203,8 @@ std::string make_utf8_seq(int codepoint) {
 
 
 
+const char utf8_to_ascii_escape_char = '_';
+
 std::string escape_utf8_with_ascii(const std::string& str)
 {
     std::string ret;
@@ -219,7 +221,7 @@ std::string escape_utf8_with_ascii(const std::string& str)
             ret += *itr;
         }
         else {
-            ret += '_';
+            ret += utf8_to_ascii_escape_char;
             // print bytes in little endian, as they appear in the string
             const int len = ::uwidth(&*itr);
             if (len <= str.end() - itr)

--- a/src/other/help.h
+++ b/src/other/help.h
@@ -60,9 +60,11 @@ namespace Help {
                                  int);
     void remove_last_utf8_char  (std::string&);
     std::string make_utf8_seq   (int codepoint);
+
+    extern const char utf8_to_ascii_escape_char;
     std::string escape_utf8_with_ascii(const std::string&);
 
-    int const utf8_bom = 0xFEFF;
+    int const  utf8_bom = 0xFEFF;
 
     void draw_shaded_text         (Torbit&, FONT*, const char*,
                                    int, int, int, int, int);

--- a/src/other/help.h
+++ b/src/other/help.h
@@ -53,12 +53,15 @@ namespace Help {
     void string_to_nice_case    (std::string&); // Alle ausser 1. Bch.
     void string_shorten         (std::string&, const FONT*, const int);
     bool string_ends_with       (const std::string&, const std::string&);
+
     // UTF-8 helpers
     void move_iterator_utf8     (std::string const&,
                                  std::string::const_iterator&,
                                  int);
     void remove_last_utf8_char  (std::string&);
     std::string make_utf8_seq   (int codepoint);
+    std::string escape_utf8_with_ascii(const std::string&);
+
     int const utf8_bom = 0xFEFF;
 
     void draw_shaded_text         (Torbit&, FONT*, const char*,

--- a/src/other/user.cpp
+++ b/src/other/user.cpp
@@ -306,7 +306,8 @@ void User::load()
     }
 
     Filename filename(gloB->dir_data_user.get_dir_rootful()
-                      + gloB->user_name + gloB->ext_level);
+                      + Help::escape_utf8_with_ascii(gloB->user_name)
+                      + gloB->ext_level);
     std::vector <IO::Line> lines;
     IO::fill_vector_from_file(lines, filename.get_rootful());
 
@@ -458,7 +459,8 @@ void User::load()
 void User::save() const
 {
     std::string filename = gloB->dir_data_user.get_rootful()
-                         + gloB->user_name + gloB->ext_level;
+                         + Help::escape_utf8_with_ascii(gloB->user_name)
+                         + gloB->ext_level;
     std::ofstream file(filename.c_str());
 
     file


### PR DESCRIPTION
Check if the unicode-to-ascii escaping does what you would do.

I'm escaping everything except A-Za-z0-9, therefore I'm also escaping dash, space, and other ascii. Should we escape dash and space or not?

Is the order of the escaping hex digits correct? I want bytes odered in little-endian, but the two hex-digits encoding a single byte shoud be big-endian: the big-endian 0x123456 should be ecoded as 0x563412 in little-endian.
